### PR TITLE
:lipstick: cursor none remove

### DIFF
--- a/pages/index/SectionContact.vue
+++ b/pages/index/SectionContact.vue
@@ -203,7 +203,6 @@ const splitLineAnimation = (item) => {
     text-align: right;
   }
   a {
-    cursor: none;
     color: var(--light-color);
     text-decoration: none;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Restored the default cursor appearance when hovering over links in the contact section, making links easier to identify and interact with.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->