### PR TITLE
Eth blocks - first enter - with firstEnterAniInProgress

### DIFF
--- a/pages/playground/eth-blocks/index.vue
+++ b/pages/playground/eth-blocks/index.vue
@@ -224,7 +224,7 @@ const blockToFullWidthAni = (block: Element) => {
   });
 };
 
-const firstBlockLoaderAni = () => {
+const firstBlockLoaderAni = async () => {
   const lastOfInitialBlock = getBlockElFromBlockId(2);
   if (!lastOfInitialBlock) return;
   blockToFullWidthAni(lastOfInitialBlock);
@@ -263,8 +263,7 @@ onMounted(async () => {
   ethBlocksAnimation.setBlockBasePosition();
   blocksBasePosition.value = ethBlocksAnimation.blocksBasePosition;
 
-  firstBlockLoaderAni();
-  newLoadingBlock();
+  await firstBlockLoaderAni();
 
   await ethBlocksAnimation.init(ethBlockEls);
 
@@ -274,6 +273,8 @@ onMounted(async () => {
 
   await ethBlocksAnimation.startRender();
   addBlockListener();
+
+  ethBlocksAnimation.firstEnterAniInProgress = false;
 
   setTimeout(() => {
     ethBlocksAnimation.loadTextures(3, 1000);

--- a/shared/types/playground/eth-blocks.ts
+++ b/shared/types/playground/eth-blocks.ts
@@ -35,6 +35,7 @@ export type EthBlocksAnimation = {
   pendingImageId: number;
   currentImageId: number;
   imageAniTimeline: gsap.core.Tween | null;
+  firstEnterAniInProgress: boolean;
 };
 
 type BlockBase = {

--- a/utils/playground/eth-blocks/eth-blocks-scene.ts
+++ b/utils/playground/eth-blocks/eth-blocks-scene.ts
@@ -21,6 +21,7 @@ export const ethBlocksAnimation: EthBlocksAnimation = {
   pendingImageId: 0,
   currentImageId: 0,
   imageAniTimeline: null,
+  firstEnterAniInProgress: true,
   setBlockBasePosition() {
     this.blocksBasePosition = window.innerHeight * this.blocksTopPadding;
   },
@@ -113,6 +114,12 @@ export const ethBlocksAnimation: EthBlocksAnimation = {
     elNode.style.transform = `scale(${Math.max(1 - aniCoef / 3, 0.75)})`;
     elNode.style.opacity = `${Math.max(1 - aniCoef * 3, 0.35)}`;
 
+    //***************************
+    //Set Active Block and trigger inageBG chagne
+    //***************************
+
+    // console.log("firstEnterAniInProgress", this.firstEnterAniInProgress);
+    if (this.firstEnterAniInProgress) return;
     if (!this.ethBlockEls) return;
     const el = this.ethBlockEls[index] as HTMLElement;
     if (!el) return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation timing and state coordination during initial load of the Ethereum blocks playground, preventing unintended block-switching behavior while the entrance animation is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->