### PR TITLE
Eth blocks - load all images on second block

### DIFF
--- a/pages/playground/eth-blocks/index.vue
+++ b/pages/playground/eth-blocks/index.vue
@@ -208,7 +208,7 @@ const blockDoneAnimate = (blockId: number) => {
   }
 
   setTimeout(() => {
-    ethBlocksAnimation.loadTextures(2, 0);
+    ethBlocksAnimation.loadTextures(25, 0);
   }, 5000);
 
   tlNewBlockAniIn.tweenTo(tlNewBlockAniIn.duration(), {
@@ -252,11 +252,13 @@ const blockDoneAnimate = (blockId: number) => {
       duration: 0,
       opacity: 1,
       onComplete: () => {
-        Canvas3.setAnimationToRender(
-          ETH_ANI_CALLBACK_NAME,
-          false,
-          "newBlockIn",
-        );
+        setTimeout(() => {
+          Canvas3.setAnimationToRender(
+            ETH_ANI_CALLBACK_NAME,
+            false,
+            "newBlockIn",
+          );
+        }, 500);
         el.classList.remove("animating");
       },
     });

--- a/utils/animations/pageTransition.ts
+++ b/utils/animations/pageTransition.ts
@@ -83,14 +83,14 @@ export const pageTransition: PageTransition = {
           Canvas3.setAnimationToRender(
             PAGE_TRANSITION_ANI_NAME,
             true,
-            "curtain",
+            "curtainIn",
           );
         },
         onComplete: () => {
           Canvas3.setAnimationToRender(
             PAGE_TRANSITION_ANI_NAME,
             false,
-            "curtain",
+            "curtainIn",
           );
           resolve();
         },
@@ -127,7 +127,7 @@ export const pageTransition: PageTransition = {
           Canvas3.setAnimationToRender(
             PAGE_TRANSITION_ANI_NAME,
             true,
-            "curtain",
+            "curtainOut",
           );
         },
         onComplete: () => {
@@ -136,9 +136,9 @@ export const pageTransition: PageTransition = {
             Canvas3.setAnimationToRender(
               PAGE_TRANSITION_ANI_NAME,
               false,
-              "curtain",
+              "curtainOut",
             );
-          },200);
+          }, 200);
           resolve();
         },
       });

--- a/utils/playground/eth-blocks/eth-blocks-scene.ts
+++ b/utils/playground/eth-blocks/eth-blocks-scene.ts
@@ -384,7 +384,7 @@ export const ethBlocksAnimation: EthBlocksAnimation = {
 
     const coef = Canvas3.getScrollSpeed() ?? 0;
     const imageChangeDuration = (
-      1.5 - Math.max(coef, DEFAULT_IMAGE_CHANGE_DURATION)
+      1.25 - Math.max(coef, DEFAULT_IMAGE_CHANGE_DURATION)
     ).toFixed(2);
 
     gsap.fromTo(
@@ -401,10 +401,15 @@ export const ethBlocksAnimation: EthBlocksAnimation = {
           );
         },
         onComplete: () => {
-          Canvas3.setAnimationToRender(
-            ETH_ANI_CALLBACK_NAME,
-            false,
-            "imageChange",
+          setTimeout(
+            () => {
+              Canvas3.setAnimationToRender(
+                ETH_ANI_CALLBACK_NAME,
+                false,
+                "imageChange",
+              );
+            },
+            Number(imageChangeDuration) * 1000,
           );
         },
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the timing of several playground and page transition animations for smoother visual transitions.
  * Adjusted block-completion and image-change animations so follow-up effects start after the animation finishes, reducing abrupt jumps.
  * Updated curtain transition states to display the correct in/out animation behavior.
  * Increased texture loading during block completion for a more complete visual effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->